### PR TITLE
Add query param serializer for Date

### DIFF
--- a/src/params_serializer.js
+++ b/src/params_serializer.js
@@ -31,6 +31,8 @@ const serialize = (key, value) => {
     v = `${value.ne.lat},${value.ne.lng},${value.sw.lat},${value.sw.lng}`;
   } else if (Array.isArray(value)) {
     v = value;
+  } else if (value instanceof Date) {
+    v = value.toISOString();
   } else if (value == null) {
     v = value;
   } else if (typeof value !== 'object') {

--- a/src/params_serializer.test.js
+++ b/src/params_serializer.test.js
@@ -27,6 +27,12 @@ describe('params serializer', () => {
     expect(ps({ alphabets: ['a', 'b', 'c'] })).toEqual('alphabets=a,b,c');
   });
 
+  it('serializes Date', () => {
+    expect(ps({ start: new Date('2018-07-01T00:00:00.000Z') })).toEqual(
+      'start=2018-07-01T00%3A00%3A00.000Z'
+    );
+  });
+
   it('throws for Objects that it can not encode', () => {
     class Point {
       construct(x, y) {


### PR DESCRIPTION
Add a serializer that handler javascript `Date` objects passed as query parameters.